### PR TITLE
feat(user/api): implement create user api

### DIFF
--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	ErrInvalidArgument = errors.New("database: invalid argument")
-	ErrNotFound        = errors.New("database: not found")
-	ErrAlreadyExists   = errors.New("database: already exists")
-	ErrNotImplemented  = errors.New("database: not implemented")
-	ErrInternal        = errors.New("database: internal")
-	ErrUnknown         = errors.New("database: unknown")
+	ErrInvalidArgument    = errors.New("database: invalid argument")
+	ErrNotFound           = errors.New("database: not found")
+	ErrFailedPrecondition = errors.New("database: failed precondition")
+	ErrAlreadyExists      = errors.New("database: already exists")
+	ErrNotImplemented     = errors.New("database: not implemented")
+	ErrInternal           = errors.New("database: internal")
+	ErrUnknown            = errors.New("database: unknown")
 )
 
 type Params struct {
@@ -41,6 +42,8 @@ func NewDatabase(params *Params) *Database {
  */
 type User interface {
 	GetByCognitoID(ctx context.Context, cognitoID string, fields ...string) (*entity.User, error)
+	Create(ctx context.Context, user *entity.User) error
+	UpdateVerified(ctx context.Context, userID string) error
 }
 
 /**
@@ -53,6 +56,9 @@ type User interface {
 func dbError(err error) error {
 	if err == nil {
 		return nil
+	}
+	if errors.Is(err, ErrFailedPrecondition) {
+		return err
 	}
 
 	//nolint:gocritic

--- a/api/internal/user/database/database_test.go
+++ b/api/internal/user/database/database_test.go
@@ -68,6 +68,11 @@ func TestDBError(t *testing.T) {
 			expect: nil,
 		},
 		{
+			name:   "internal error to failed precondition",
+			err:    ErrFailedPrecondition,
+			expect: ErrFailedPrecondition,
+		},
+		{
 			name:   "mysql error",
 			err:    &mysql.MySQLError{},
 			expect: ErrUnknown,

--- a/api/internal/user/database/user_test.go
+++ b/api/internal/user/database/user_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUser(t *testing.T) {
+	assert.NotNil(t, NewUser(nil))
+}
+
 func TestUser_GetByCognitoID(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -85,6 +89,153 @@ func TestUser_GetByCognitoID(t *testing.T) {
 			assert.NoError(t, err)
 			fillIgnoreUserField(actual, now())
 			assert.Equal(t, tt.want.user, actual)
+		})
+	}
+}
+
+func TestUser_Create(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m, err := newMocks(ctrl)
+	require.NoError(t, err)
+	current := jst.Date(2022, 1, 2, 18, 30, 0, 0)
+	now := func() time.Time {
+		return current
+	}
+
+	type args struct {
+		user *entity.User
+	}
+	type want struct {
+		hasErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				user: testUser("user-id", "test-user@and-period.jp", "+810000000000", now()),
+			},
+			want: want{
+				hasErr: false,
+			},
+		},
+		{
+			name: "failed to duplicate entry",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				u := testUser("user-id", "test-user@and-period.jp", "+810000000000", now())
+				err = m.db.DB.Create(&u).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				user: testUser("user-id", "test-user@and-period.jp", "+810000000000", now()),
+			},
+			want: want{
+				hasErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := m.dbDelete(ctx, userTable)
+			require.NoError(t, err)
+			tt.setup(ctx, t, m)
+
+			db := &user{db: m.db, now: now}
+			err = db.Create(ctx, tt.args.user)
+			assert.Equal(t, tt.want.hasErr, err != nil, err)
+		})
+	}
+}
+
+func TestUser_UpdateVerified(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m, err := newMocks(ctrl)
+	require.NoError(t, err)
+	current := jst.Date(2022, 1, 2, 18, 30, 0, 0)
+	now := func() time.Time {
+		return current
+	}
+
+	type args struct {
+		userID string
+	}
+	type want struct {
+		hasErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				u := testUser("user-id", "test-user@and-period.jp", "+810000000000", now())
+				err = m.db.DB.Create(&u).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				userID: "user-id",
+			},
+			want: want{
+				hasErr: false,
+			},
+		},
+		{
+			name:  "failed to not found",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				userID: "user-id",
+			},
+			want: want{
+				hasErr: true,
+			},
+		},
+		{
+			name: "failed to verified at is not zero value",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				u := testUser("user-id", "test-user@and-period.jp", "+810000000000", now())
+				u.VerifiedAt = now()
+				err = m.db.DB.Create(&u).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				userID: "user-id",
+			},
+			want: want{
+				hasErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := m.dbDelete(ctx, userTable)
+			require.NoError(t, err)
+			tt.setup(ctx, t, m)
+
+			db := &user{db: m.db, now: now}
+			err = db.UpdateVerified(ctx, tt.args.userID)
+			assert.Equal(t, tt.want.hasErr, err != nil, err)
 		})
 	}
 }

--- a/api/internal/user/entity/user.go
+++ b/api/internal/user/entity/user.go
@@ -25,3 +25,13 @@ type User struct {
 	VerifiedAt   time.Time      `gorm:"default:null"`
 	DeletedAt    gorm.DeletedAt `gorm:"default:null"`
 }
+
+func NewUser(id, cognitoID string, provider ProviderType, email, phoneNumber string) *User {
+	return &User{
+		ID:           id,
+		CognitoID:    cognitoID,
+		ProviderType: provider,
+		Email:        email,
+		PhoneNumber:  phoneNumber,
+	}
+}

--- a/api/mock/user/database/database.go
+++ b/api/mock/user/database/database.go
@@ -35,6 +35,20 @@ func (m *MockUser) EXPECT() *MockUserMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockUser) Create(ctx context.Context, user *entity.User) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, user)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockUserMockRecorder) Create(ctx, user interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUser)(nil).Create), ctx, user)
+}
+
 // GetByCognitoID mocks base method.
 func (m *MockUser) GetByCognitoID(ctx context.Context, cognitoID string, fields ...string) (*entity.User, error) {
 	m.ctrl.T.Helper()
@@ -53,4 +67,18 @@ func (mr *MockUserMockRecorder) GetByCognitoID(ctx, cognitoID interface{}, field
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, cognitoID}, fields...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByCognitoID", reflect.TypeOf((*MockUser)(nil).GetByCognitoID), varargs...)
+}
+
+// UpdateVerified mocks base method.
+func (m *MockUser) UpdateVerified(ctx context.Context, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVerified", ctx, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateVerified indicates an expected call of UpdateVerified.
+func (mr *MockUserMockRecorder) UpdateVerified(ctx, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVerified", reflect.TypeOf((*MockUser)(nil).UpdateVerified), ctx, userID)
 }

--- a/api/pkg/database/client_test.go
+++ b/api/pkg/database/client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestNewClient(t *testing.T) {
@@ -72,6 +73,25 @@ func TestBeginAndClose(t *testing.T) {
 	require.NoError(t, err)
 	f := client.Close(tx)
 	require.NotNil(t, f)
+}
+
+func TestTransaction(t *testing.T) {
+	setEnv()
+	params := &Params{
+		Socket:   "tcp",
+		Host:     os.Getenv("DB_HOST"),
+		Port:     os.Getenv("DB_PORT"),
+		Database: "users",
+		Username: os.Getenv("DB_USERNAME"),
+		Password: os.Getenv("DB_PASSWORD"),
+	}
+	client, err := NewClient(params)
+	require.NoError(t, err)
+	data, err := client.Transaction(func(tx *gorm.DB) (interface{}, error) {
+		return "data", nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, data)
 }
 
 func TestGetConfig(t *testing.T) {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
ユーザー登録(メール/SMS認証)APIの実装を行いました。

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->
* https://calmato.kibe.la/notes/662

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
