### PR TITLE
feat(infra): setup sidecar for proxy

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,50 @@
+# -*- mode: Python -*-
+
+if k8s_context() != 'docker-desktop':
+  fail('failed to connect kubernetes cluster for local env')
+
+allow_k8s_contexts('docker-desktop')
+
+##################################################
+# User Gateway
+##################################################
+docker_build(
+  'marche/user-gateway',
+  '.',
+  dockerfile='infra/docker/api/gateway/user/Dockerfile'
+)
+
+k8s_yaml(helm(
+  'infra/helm/gateway',
+  name='user-gateway',
+  namespace='default',
+  values=['./api/config/gateway/user/dev.yaml']
+))
+
+k8s_resource(
+  'user-gateway',
+  port_forwards=['18000:9000', '18001:9001', '18002:9002'],
+  labels=['gateway']
+)
+
+##################################################
+# User Servcer
+##################################################
+docker_build(
+  'marche/user-server',
+  '.',
+  dockerfile='infra/docker/api/user/server/Dockerfile'
+)
+
+k8s_yaml(helm(
+  'infra/helm/service',
+  name='user-server',
+  namespace='default',
+  values=['./api/config/user/server/dev.yaml']
+))
+
+k8s_resource(
+  'user-server',
+  port_forwards=['19000:9000', '19001:9001', '19002:9002'],
+  labels=['service']
+)

--- a/api/config/gateway/user/dev.yaml.temp
+++ b/api/config/gateway/user/dev.yaml.temp
@@ -1,0 +1,59 @@
+nameOverride: user-gateway
+
+replicaCount: 1
+revisionHistoryLimit: 5
+
+image:
+  repository: marche/user-gateway
+  pullPolicy: Always
+  tag: ""
+
+service:
+  enabled: true
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9002
+  internalPort: 9002
+
+app:
+  port: 9000
+  proxyHost: "127.0.0.1:9003"
+
+metrics:
+  enabled: true
+  port: 9001
+
+envoy:
+  enabled: true
+  image:
+    repository: envoyproxy/envoy-alpine
+    pullPolicy: IfNotPresent
+    tag: "v1.21.1"
+  config: "configs/user-gateway-dev-envoy.yaml"
+  admin:
+    port: 9004
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+health:
+  liveness:
+    enabled: true
+    path: /health
+    port: 9000
+    interval: 3
+    initialDelay: 20
+  readiness:
+    enabled: true
+    path: /health
+    port: 9000
+    interval: 3
+    initialDelay: 20
+
+env:
+- name: LOG_LEVEL
+  value: "info"
+- name: SHUTDOWN_DELAY_SEC
+  value: "0"

--- a/api/config/user/server/dev.yaml.temp
+++ b/api/config/user/server/dev.yaml.temp
@@ -1,0 +1,84 @@
+nameOverride: user-server
+
+replicaCount: 1
+revisionHistoryLimit: 5
+
+image:
+  repository: marche/user-server
+  pullPolicy: Always
+  tag: ""
+
+service:
+  enabled: true
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9002
+  internalPort: 9002
+
+app:
+  port: 9000
+  proxyHost: "127.0.0.1:9003"
+
+metrics:
+  enabled: true
+  port: 9001
+
+envoy:
+  enabled: true
+  image:
+    repository: envoyproxy/envoy-alpine
+    pullPolicy: IfNotPresent
+    tag: v1.21.1
+  config: "configs/user-server-dev-envoy.yaml"
+  admin:
+    port: 9004
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+health:
+  liveness:
+    enabled: true
+    port: 9000
+    interval: 3
+    initialDelay: 20
+  readiness:
+    enabled: true
+    port: 9000
+    interval: 3
+    initialDelay: 20
+
+env:
+- name: LOG_LEVEL
+  value: "info"
+- name: SHUTDOWN_DELAY_SEC
+  value: "0"
+
+database:
+  enabled: true
+  host: ""
+  port: "3306"
+  username: ""
+  password: ""
+  timezone: UTC
+  enabledTls: true
+
+awsCredentials:
+  enabled: true
+  region: ap-northeast-1
+  accessKey: ""
+  secretKey: ""
+
+cognitoCredentials:
+  enabled: true
+  userPoolId: ""
+  clientId: ""

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.13.0
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
+	github.com/gin-contrib/gzip v0.0.5
 	github.com/gin-contrib/zap v0.0.2
 	github.com/gin-gonic/gin v1.7.7
 	github.com/go-sql-driver/mysql v1.6.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -99,10 +99,13 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gin-contrib/gzip v0.0.5 h1:mhnVU32YnnBh2LPH2iqRqsA/eR7SAqRaD388jL2s/j0=
+github.com/gin-contrib/gzip v0.0.5/go.mod h1:OPIK6HR0Um2vNmBUTlayD7qle4yVVRZT0PyhdUigrKk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-contrib/zap v0.0.2 h1:VnIucI+kUsxgzmcrX0gMk19a2I12KirTxi+ufuT2xZk=
 github.com/gin-contrib/zap v0.0.2/go.mod h1:2vZj8gTuOYOfottCirxZr9gNM/Q1yk2iSVn15SUVG5A=
+github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/gin-gonic/gin v1.7.7 h1:3DoBmSbJbZAWqXJC3SLjAPfutPJJRN1U5pALB7EeTTs=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/api/internal/gateway/cmd/user/config.go
+++ b/api/internal/gateway/cmd/user/config.go
@@ -13,6 +13,7 @@ type config struct {
 	LogPath          string `envconfig:"LOG_PATH" default:""`
 	LogLevel         string `envconfig:"LOG_LEVEL" default:"info"`
 	GRPCInsecure     bool   `envconfig:"GRPC_INSECURE" default:"true"`
+	ProxyHost        string `envconfig:"PROXY_HOST" default:""`
 	UserServiceURL   string `envconfig:"USER_SERVICE_URL" default:""`
 }
 

--- a/api/internal/gateway/cmd/user/exec.go
+++ b/api/internal/gateway/cmd/user/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/and-period/marche/api/pkg/cors"
 	"github.com/and-period/marche/api/pkg/http"
 	"github.com/and-period/marche/api/pkg/log"
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -94,7 +95,7 @@ func newApp(conf *config) (*app, error) {
 	}
 
 	// HTTP Serverの設定
-	httpOpts := []gin.HandlerFunc{gin.Recovery()}
+	httpOpts := []gin.HandlerFunc{gin.Recovery(), gzip.Gzip(gzip.DefaultCompression)}
 
 	cm := cors.NewGinMiddleware()
 	httpOpts = append(httpOpts, cm)

--- a/api/internal/gateway/cmd/user/registry.go
+++ b/api/internal/gateway/cmd/user/registry.go
@@ -66,6 +66,10 @@ func newGRPCClient(conf *config) (*gRPCClient, error) {
 		return nil, err
 	}
 
+	if conf.ProxyHost != "" {
+		conf.UserServiceURL = conf.ProxyHost
+	}
+
 	userConn, err := grpc.Dial(conf.UserServiceURL, opts...)
 	if err != nil {
 		return nil, err

--- a/api/pkg/grpc/health.go
+++ b/api/pkg/grpc/health.go
@@ -1,0 +1,26 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+type healthServer struct{}
+
+func RegisterHealthServer(s *grpc.Server) {
+	health.RegisterHealthServer(s, &healthServer{})
+}
+
+func (s *healthServer) Check(ctx context.Context, req *health.HealthCheckRequest) (*health.HealthCheckResponse, error) {
+	return &health.HealthCheckResponse{
+		Status: health.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (s *healthServer) Watch(*health.HealthCheckRequest, health.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "Watching is not supported")
+}

--- a/api/pkg/grpc/health_test.go
+++ b/api/pkg/grpc/health_test.go
@@ -1,0 +1,27 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestHealthServer(t *testing.T) {
+	tests := []struct {
+		name   string
+		server *grpc.Server
+	}{
+		{
+			name:   "success",
+			server: grpc.NewServer(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterHealthServer(tt.server)
+			assert.NotNil(t, tt.server)
+		})
+	}
+}

--- a/api/pkg/grpc/server.go
+++ b/api/pkg/grpc/server.go
@@ -23,7 +23,9 @@ func NewGRPCServer(server *grpc.Server, port int64) (Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("grpc: failed to listen port: %w", err)
 	}
-	return &gRPCServer{server: server, lister: lis}, nil
+	s := &gRPCServer{server: server, lister: lis}
+	s.registerHealthServer()
+	return s, nil
 }
 
 // Serve - サーバーの起動
@@ -34,4 +36,9 @@ func (s *gRPCServer) Serve() error {
 // Stop - サーバーの停止
 func (s *gRPCServer) Stop() {
 	s.server.GracefulStop()
+}
+
+// registerHealthServer - ヘルスチェックエンドポイントの追加
+func (s *gRPCServer) registerHealthServer() {
+	RegisterHealthServer(s.server)
 }

--- a/api/pkg/grpc/server_test.go
+++ b/api/pkg/grpc/server_test.go
@@ -17,7 +17,7 @@ func TestGRPCServer(t *testing.T) {
 	}{
 		{
 			name:   "success",
-			server: &grpc.Server{},
+			server: grpc.NewServer(),
 			port:   28080,
 			isErr:  false,
 		},

--- a/api/pkg/log/gin.go
+++ b/api/pkg/log/gin.go
@@ -12,5 +12,9 @@ func NewGinMiddleware(params *Params) (gin.HandlerFunc, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ginzap.Ginzap(logger, time.RFC3339, true), nil
+	return ginzap.GinzapWithConfig(logger, &ginzap.Config{
+		TimeFormat: time.RFC3339,
+		UTC:        false,
+		SkipPaths:  []string{"/health"},
+	}), nil
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,37 +5,37 @@ services:
     container_name: user_gateway
     build:
       context: .
-      dockerfile: ./infra/docker/api/gateway/user/Dockerfile.development
+      dockerfile: ./infra/docker/api/gateway/user/Dockerfile.local
     working_dir: /go/src/github.com/and-period/marche/api
     volumes:
       - ./api:/go/src/github.com/and-period/marche/api:cached
       - ./tmp/data/go/pkg/mod:/go/pkg/mod:delegated
       - ./tmp/logs/api/gateway/user:/var/log/api:delegated
     environment:
-      - PORT=8080
-      - METRICS_PORT=9090
+      - PORT=9000
+      - METRICS_PORT=9001
       - SHUTDOWN_DELAY_SEC=0
       - LOG_LEVEL=debug
       - LOG_PATH=/var/log/api
-      - USER_SERVICE_URL=user_api:8080
+      - USER_SERVICE_URL=user_api:9000
     ports:
-      - 18000:8080
-      - 18001:9090
+      - 18000:9000
+      - 18001:9001
     command: make dev SERVICE=gateway/user
 
   user_api:
     container_name: user_api
     build:
       context: .
-      dockerfile: ./infra/docker/api/user/server/Dockerfile.development
+      dockerfile: ./infra/docker/api/user/server/Dockerfile.local
     working_dir: /go/src/github.com/and-period/marche/api
     volumes:
       - ./api:/go/src/github.com/and-period/marche/api:cached
       - ./tmp/data/go/pkg/mod:/go/pkg/mod:delegated
       - ./tmp/logs/api/user/server:/var/log/api:delegated
     environment:
-      - PORT=8080
-      - METRICS_PORT=9090
+      - PORT=9000
+      - METRICS_PORT=9001
       - SHUTDOWN_DELAY_SEC=0
       - LOG_LEVEL=debug
       - LOG_PATH=/var/log/api
@@ -51,8 +51,8 @@ services:
       - COGNITO_USER_POOL_ID=${COGNITO_USER_POOL_ID}
       - COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}
     ports:
-      - 19000:8080
-      - 19001:9090
+      - 19000:9000
+      - 19001:9001
     command: make dev SERVICE=user/server
 
   mysql_test:

--- a/infra/docker/api/gateway/user/Dockerfile
+++ b/infra/docker/api/gateway/user/Dockerfile
@@ -26,5 +26,5 @@ RUN apk add --update --no-cache \
 
 COPY --from=builder /go/src/github.com/and-period/marche/api/app ./app
 
-EXPOSE 8080 9090
+EXPOSE 9000 9001
 CMD ["./app"]

--- a/infra/docker/api/user/server/Dockerfile
+++ b/infra/docker/api/user/server/Dockerfile
@@ -26,5 +26,5 @@ RUN apk add --update --no-cache \
 
 COPY --from=builder /go/src/github.com/and-period/marche/api/app ./app
 
-EXPOSE 8080 9090
+EXPOSE 9000 9001
 CMD ["./app"]

--- a/infra/docker/infra/envoy/Dockerfile
+++ b/infra/docker/infra/envoy/Dockerfile
@@ -1,0 +1,4 @@
+FROM envoyproxy/envoy-alpine:v1.21.1
+
+ENV LANG C.UTF-8
+ENV TZ Asia/Tokyo

--- a/infra/helm/gateway/.helmignore
+++ b/infra/helm/gateway/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/helm/gateway/Chart.yaml
+++ b/infra/helm/gateway/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gateway
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/infra/helm/gateway/configs/user-gateway-dev-envoy.yaml
+++ b/infra/helm/gateway/configs/user-gateway-dev-envoy.yaml
@@ -1,0 +1,210 @@
+# v1.21.1
+admin:
+  access_log:
+    name: envoy.access_loggers.file
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9004
+cluster_manager:
+  outlier_detection:
+    event_log_path: /dev/stdout
+static_resources:
+  listeners:
+  - name: ingress
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9002
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          access_log:
+            name: envoy.file_access_log
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+              log_format:
+                json_format:
+                  agent: "%REQ(USER-AGENT)%"
+                  duration: "%DURATION%"
+                  eventTime: "%START_TIME(%s.%6f)%"
+                  ip: "%REQ(X-FORWARDED-FOR)%"
+                  kind: "accesslog"
+                  message: "envoy access log"
+                  method: "%REQ(:METHOD)%"
+                  path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                  receivedBodySize: "%BYTES_RECEIVED%"
+                  responseDuration: "%RESPONSE_DURATION%"
+                  sentBodySize: "%BYTES_SENT%"
+                  severity: "INFO"
+                  status: "%RESPONSE_CODE%"
+          http_filters:
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: false
+              headers:
+              - name: ":path"
+                string_match:
+                  exact: /
+              cluster_min_healthy_percentages:
+                "user-gateway":
+                  value: 100
+          - name: envoy.filters.http.compressor
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              request_direction_config:
+                common_config:
+                  enabled:
+                    default_value: false
+                    runtime_key: request_compressor_enabled
+              response_direction_config:
+                common_config:
+                  content_type:
+                  - application/json
+                disable_on_etag_header: true
+              compressor_library:
+                name: envoy.compression.gzip.compressor
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+          - name: envoy.filters.http.cors
+            typed_config: {}
+          - name: envoy.filters.http.router
+            typed_config: {}
+          route_config:
+            name: ingress_routes
+            virtual_hosts:
+            - name: ingress_services
+              domains:
+              - "*"
+              routes:
+              - route:
+                  weighted_clusters:
+                    clusters:
+                    - name: user-gateway
+                      weight: 100
+                  timeout: 200s
+                  retry_policy:
+                    retry_on: 5xx
+                    num_retries: 2
+                    host_selection_retry_max_attempts: 2
+                match:
+                  prefix: /
+  - name: egress
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 9003
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: egress_http
+          codec_type: AUTO
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config: {}
+          route_config:
+            name: egress_routes
+            virtual_hosts:
+            - name: egress_services
+              domains:
+              - "*"
+              routes:
+              - route:
+                  cluster: user-server
+                  retry_policy:
+                    retry_on: unavailable,internal
+                    num_retries: 3
+                    host_selection_retry_max_attempts: 3
+                match:
+                  prefix: /user.UserService
+                  headers:
+                  - name: content-type
+                    string_match:
+                      exact: application/grpc
+  clusters:
+  - name: user-gateway
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    dns_lookup_family: V4_ONLY
+    connect_timeout: 0.25s
+    health_checks:
+    - healthy_threshold: 1
+      unhealthy_threshold: 3
+      interval: 1s
+      interval_jitter: 1s
+      no_traffic_interval: 1s
+      timeout: 3s
+      event_log_path: /dev/stdout
+      always_log_health_check_failures: true
+      http_health_check:
+        path: /health
+    load_assignment:
+      cluster_name: user-gateway
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address:  127.0.0.1
+                port_value: 9000
+    ignore_health_on_host_removal: true
+    circuit_breakers:
+      thresholds:
+      - priority: DEFAULT
+        max_connections: 1024
+        max_pending_requests: 2048
+        max_requests: 2048
+        max_retries: 3
+  - name: user-server
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    dns_lookup_family: V4_ONLY
+    connect_timeout: 0.25s
+    health_checks:
+    - healthy_threshold: 1
+      unhealthy_threshold: 3
+      interval: 1s
+      interval_jitter: 1s
+      no_traffic_interval: 1s
+      timeout: 3s
+      event_log_path: /dev/stdout
+      always_log_health_check_failures: true
+      grpc_health_check: {}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: user-server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: user-server.default.svc.cluster.local
+                port_value: 9002
+    ignore_health_on_host_removal: true
+    outlier_detection:
+      consecutive_5xx: 5
+      consecutive_gateway_failure: 5
+      interval: 5s
+      base_ejection_time: 30s
+      max_ejection_percent: 10
+      enforcing_consecutive_5xx: 100
+      enforcing_success_rate: 100
+      enforcing_consecutive_gateway_failure: 0
+      success_rate_minimum_hosts: 5
+      success_rate_request_volume: 100
+      success_rate_stdev_factor: 1900

--- a/infra/helm/gateway/templates/_helpers.tpl
+++ b/infra/helm/gateway/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gateway.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gateway.labels" -}}
+helm.sh/chart: {{ include "gateway.chart" . }}
+{{ include "gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infra/helm/gateway/templates/configmap.yaml
+++ b/infra/helm/gateway/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.envoy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gateway.fullname" . }}-envoy-config
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+{{ .Files.Get .Values.envoy.config | indent 4 }}
+{{- end -}}

--- a/infra/helm/gateway/templates/deployment.yaml
+++ b/infra/helm/gateway/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gateway.fullname" . }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gateway.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}"
+        {{- end }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        ports:
+        - name: default
+          protocol: TCP
+          containerPort: {{ .Values.app.port }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          protocol: TCP
+          containerPort: {{ .Values.metrics.port }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- if and .Values.health.liveness .Values.health.liveness.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.health.liveness.path }}
+            port: {{ .Values.health.liveness.port }}
+          initialDelaySeconds: {{ default 10 .Values.health.liveness.initialDelay }}
+          periodSeconds: {{ default 5 .Values.health.liveness.interval }}
+          failureThreshold: 3
+        {{- end }}
+        {{- if and .Values.health.readiness .Values.health.readiness.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.health.readiness.path }}
+            port: {{ .Values.health.readiness.port }}
+          initialDelaySeconds: {{ default 10 .Values.health.readiness.initialDelay }}
+          periodSeconds: {{ .Values.health.readiness.interval }}
+          failureThreshold: 3
+        {{- end }}
+        env:
+        - name: PORT
+          value: {{ .Values.app.port | quote }}
+        {{- if .Values.metrics.enabled }}
+        - name: METRICS_PORT
+          value: {{ .Values.metrics.port | quote }}
+        {{- end }}
+        {{- if .Values.envoy.enabled }}
+        - name: PROXY_HOST
+          value: {{ .Values.app.proxyHost | quote }}
+        {{- end }}
+        {{- toYaml .Values.env | nindent 8 }}
+      {{- if .Values.envoy.enabled }}
+      - name: envoy
+        image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+        imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+        ports:
+        - name: default
+          protocol: TCP
+          containerPort: {{ .Values.service.internalPort }}
+        - name: admin
+          protocol: TCP
+          containerPort: {{ .Values.envoy.admin.port }}
+        resources:
+          limits:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy
+          readOnly: true
+      {{- end }}
+      volumes:
+      {{- if .Values.envoy.enabled }}
+      - name: envoy-config
+        configMap:
+          name: {{ include "gateway.fullname" . }}-envoy-config
+      {{- end }}

--- a/infra/helm/gateway/templates/service.yaml
+++ b/infra/helm/gateway/templates/service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gateway.fullname" . }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "gateway.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+  {{- if .Values.metrics.enabled }}
+  - name: metrics
+    protocol: TCP
+    port: {{ .Values.metrics.port }}
+    targetPort: {{ .Values.metrics.port }}
+  {{- end }}
+  {{- if .Values.envoy.enabled }}
+  - name: admin
+    protocol: TCP
+    port: {{ .Values.envoy.admin.port }}
+    targetPort: {{ .Values.envoy.admin.port }}
+  {{- end }}
+{{- end -}}

--- a/infra/helm/gateway/values.yaml
+++ b/infra/helm/gateway/values.yaml
@@ -1,0 +1,67 @@
+# Default values for gateway.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+nameOverride: ""
+
+replicaCount: 1
+revisionHistoryLimit: 5
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: latest
+
+service:
+  enabled: true
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9002
+  internalPort: 9000
+
+app:
+  port: 9000
+  proxyHost: "127.0.0.1:9003"
+
+metrics:
+  enabled: true
+  port: 9001
+
+envoy:
+  enabled: true
+  image:
+    repository: envoyproxy/envoy-alpine
+    pullPolicy: IfNotPresent
+    tag: v1.21.1
+  config: ""
+  admin:
+    port: 9004
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+health:
+  liveness:
+    enabled: true
+    path: /health
+    port: 9000
+    interval: 3
+    initialDelay: 20
+  readiness:
+    enabled: true
+    path: /health
+    port: 9000
+    interval: 3
+    initialDelay: 20
+
+env: {}
+  # - name: ENV_NAME
+  #   value: "value"

--- a/infra/helm/service/.helmignore
+++ b/infra/helm/service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/helm/service/Chart.yaml
+++ b/infra/helm/service/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: service
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/infra/helm/service/configs/user-server-dev-envoy.yaml
+++ b/infra/helm/service/configs/user-server-dev-envoy.yaml
@@ -1,0 +1,198 @@
+# v1.21.1
+admin:
+  access_log:
+    name: envoy.access_loggers.file
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9004
+cluster_manager:
+  outlier_detection:
+    event_log_path: /dev/stdout
+static_resources:
+  listeners:
+  - name: ingress
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9002
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          access_log:
+            name: envoy.file_access_log
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+              log_format:
+                json_format:
+                  agent: "%REQ(USER-AGENT)%"
+                  duration: "%DURATION%"
+                  eventTime: "%START_TIME(%s.%6f)%"
+                  ip: "%REQ(X-FORWARDED-FOR)%"
+                  kind: "accesslog"
+                  message: "envoy access log"
+                  method: "%REQ(:METHOD)%"
+                  path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                  receivedBodySize: "%BYTES_RECEIVED%"
+                  responseDuration: "%RESPONSE_DURATION%"
+                  sentBodySize: "%BYTES_SENT%"
+                  severity: "INFO"
+                  status: "%RESPONSE_CODE%"
+          http_filters:
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: false
+              headers:
+              - name: ":path"
+                string_match:
+                  exact: /health
+              cluster_min_healthy_percentages:
+                "user-server":
+                  value: 100
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: true
+              headers:
+              - name: ":path"
+                string_match:
+                  exact: /grpc.health.v1.Health/Check
+          - name: envoy.filters.http.router
+            typed_config: {}
+          route_config:
+            name: ingress_routes
+            virtual_hosts:
+            - name: ingress_services
+              domains:
+              - "*"
+              routes:
+              - route:
+                  weighted_clusters:
+                    clusters:
+                    - name: user-server
+                      weight: 100
+                match:
+                  prefix: /
+                  headers:
+                  - name: content-type
+                    string_match:
+                      exact: application/grpc
+  - name: egress
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 9003
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: egress_http
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config: {}
+          route_config:
+            name: egress_routes
+            virtual_hosts:
+            - name: egress_services
+              domains:
+              - "*"
+              routes: []
+              # - route:
+              #     cluster: messenger-server
+              #   match:
+              #     prefix: /messenger.MessengerService
+              #     headers:
+              #     - name: content-type
+              #       string_match:
+              #         exact: application/grpc
+  clusters:
+  - name: user-server
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    dns_lookup_family: V4_ONLY
+    connect_timeout: 0.25s
+    health_checks:
+    - healthy_threshold: 1
+      unhealthy_threshold: 3
+      interval: 1s
+      interval_jitter: 1s
+      no_traffic_interval: 1s
+      timeout: 3s
+      event_log_path: /dev/stdout
+      always_log_health_check_failures: true
+      grpc_health_check: {}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: user-server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 9000
+    ignore_health_on_host_removal: true
+    circuit_breakers:
+      thresholds:
+      - priority: DEFAULT
+        max_connections: 1024
+        max_pending_requests: 2048
+        max_requests: 2048
+        max_retries: 3
+  # - name: messenger-server
+  #   type: STRICT_DNS
+  #   lb_policy: ROUND_ROBIN
+  #   dns_lookup_family: V4_ONLY
+  #   connect_timeout: 0.25s
+  #   health_checks:
+  #   - healthy_threshold: 1
+  #     unhealthy_threshold: 3
+  #     interval: 1s
+  #     interval_jitter: 1s
+  #     no_traffic_interval: 1s
+  #     timeout: 3s
+  #     event_log_path: /dev/stdout
+  #     always_log_health_check_failures: true
+  #     grpc_health_check: {}
+  #   typed_extension_protocol_options:
+  #     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+  #       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+  #       explicit_http_config:
+  #         http2_protocol_options: {}
+  #   load_assignment:
+  #     cluster_name: messenger-server
+  #     endpoints:
+  #     - lb_endpoints:
+  #       - endpoint:
+  #           address:
+  #             socket_address:
+  #               address: messenger-server.default.svc.cluster.local
+  #               port_value: 9002
+  #   ignore_health_on_host_removal: true
+  #   outlier_detection:
+  #     consecutive_5xx: 5
+  #     consecutive_gateway_failure: 5
+  #     interval: 5s
+  #     base_ejection_time: 30s
+  #     max_ejection_percent: 10
+  #     enforcing_consecutive_5xx: 100
+  #     enforcing_success_rate: 100
+  #     enforcing_consecutive_gateway_failure: 0
+  #     success_rate_minimum_hosts: 5
+  #     success_rate_request_volume: 100
+  #     success_rate_stdev_factor: 1900

--- a/infra/helm/service/templates/_helpers.tpl
+++ b/infra/helm/service/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "service.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "service.labels" -}}
+helm.sh/chart: {{ include "service.chart" . }}
+{{ include "service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infra/helm/service/templates/configmap.yaml
+++ b/infra/helm/service/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.envoy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "service.fullname" . }}-envoy-config
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+{{ .Files.Get .Values.envoy.config | indent 4 }}
+{{- end -}}

--- a/infra/helm/service/templates/deployment.yaml
+++ b/infra/helm/service/templates/deployment.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "service.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}"
+        {{- end }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        ports:
+        - name: default
+          protocol: TCP
+          containerPort: {{ .Values.app.port }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          protocol: TCP
+          containerPort: {{ .Values.metrics.port }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- if and .Values.health.liveness .Values.health.liveness.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: {{.Values.health.liveness.port}}
+          initialDelaySeconds: {{ default 10 .Values.health.liveness.initialDelay }}
+          periodSeconds: {{ default 5 .Values.health.liveness.interval }}
+          failureThreshold: 3
+        {{- end }}
+        {{- if and .Values.health.readiness .Values.health.readiness.enabled }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ default 5 .Values.health.readiness.port }}
+          initialDelaySeconds: {{ default 10 .Values.health.readiness.initialDelay }}
+          periodSeconds: {{ default 5 .Values.health.readiness.interval }}
+          periodSeconds: 5
+          failureThreshold: 3
+        {{- end }}
+        env:
+        - name: PORT
+          value: {{ .Values.app.port | quote }}
+        {{- if .Values.metrics.enabled }}
+        - name: METRICS_PORT
+          value: {{ .Values.metrics.port | quote }}
+        {{- end }}
+        {{- if .Values.envoy.enabled }}
+        - name: PROXY_HOST
+          value: {{ .Values.app.proxyHost | quote }}
+        {{- end }}
+        {{- if .Values.database.enabled }}
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-database-secret
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-database-secret
+              key: DB_PORT
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-database-secret
+              key: DB_USERNAME
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-database-secret
+              key: DB_PASSWORD
+        - name: DB_DATABASE
+          value: {{ .Values.database.database | quote }}
+        - name: DB_TIMEZONE
+          value: {{ .Values.database.timezone | quote }}
+        - name: DB_ENABLED_TLS
+          value: {{ .Values.database.enabledTls | quote }}
+        {{- end }}
+        {{- if and .Values.awsCredentials .Values.awsCredentials.enabled }}
+        - name: AWS_REGION
+          value: "{{ .Values.awsCredentials.region }}"
+        - name: AWS_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-aws-secret
+              key: AWS_ACCESS_KEY
+        - name: AWS_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-aws-secret
+              key: AWS_SECRET_KEY
+        {{- end }}
+        {{- if and .Values.cognitoCredentials .Values.cognitoCredentials.enabled }}
+        - name: COGNITO_USER_POOL_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-cognito-secret
+              key: COGNITO_USER_POOL_ID
+        - name: COGNITO_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "service.fullname" . }}-cognito-secret
+              key: COGNITO_CLIENT_ID
+        {{- end }}
+        {{- toYaml .Values.env | nindent 8 }}
+      {{- if .Values.envoy.enabled }}
+      - name: envoy
+        image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+        imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+        ports:
+        - name: default
+          protocol: TCP
+          containerPort: {{ .Values.service.internalPort }}
+        - name: admin
+          protocol: TCP
+          containerPort: {{ .Values.envoy.admin.port }}
+        resources:
+          limits:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy
+          readOnly: true
+      {{- end }}
+      volumes:
+      {{- if .Values.envoy.enabled }}
+      - name: envoy-config
+        configMap:
+          name: {{ include "service.fullname" . }}-envoy-config
+      {{- end }}

--- a/infra/helm/service/templates/secret.yaml
+++ b/infra/helm/service/templates/secret.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.database.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service.fullname" . }}-database-secret
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+data:
+  DB_HOST: {{ .Values.database.host | b64enc | quote }}
+  DB_PORT: {{ .Values.database.port | b64enc | quote }}
+  DB_USERNAME: {{ .Values.database.username | b64enc | quote }}
+  DB_PASSWORD: {{ .Values.database.password | b64enc | quote }}
+{{- end }}
+{{- if and .Values.awsCredentials .Values.awsCredentials.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service.fullname" . }}-aws-secret
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+data:
+  AWS_ACCESS_KEY: {{ .Values.awsCredentials.accessKey | b64enc | quote }}
+  AWS_SECRET_KEY: {{ .Values.awsCredentials.secretKey | b64enc | quote }}
+{{- end }}
+{{- if and .Values.cognitoCredentials .Values.cognitoCredentials.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service.fullname" . }}-cognito-secret
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+data:
+  COGNITO_USER_POOL_ID: {{ .Values.cognitoCredentials.userPoolId | b64enc | quote }}
+  COGNITO_CLIENT_ID: {{ .Values.cognitoCredentials.clientId | b64enc | quote }}
+{{- end }}

--- a/infra/helm/service/templates/service.yaml
+++ b/infra/helm/service/templates/service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "service.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: grpc
+    protocol: TCP
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+  {{- if .Values.metrics.enabled }}
+  - name: metrics
+    protocol: TCP
+    port: {{ .Values.metrics.port }}
+    targetPort: {{ .Values.metrics.port }}
+  {{- end }}
+  {{- if .Values.envoy.enabled }}
+  - name: admin
+    protocol: TCP
+    port: {{ .Values.envoy.admin.port }}
+    targetPort: {{ .Values.envoy.admin.port }}
+  {{- end }}
+{{- end -}}

--- a/infra/helm/service/values.yaml
+++ b/infra/helm/service/values.yaml
@@ -1,0 +1,85 @@
+# Default values for service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+nameOverride: ""
+
+replicaCount: 1
+revisionHistoryLimit: 5
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  enabled: true
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9002
+  internalPort: 9002
+
+app:
+  port: 9000
+  proxyHost: "127.0.0.1:9003"
+
+metrics:
+  enabled: true
+  port: 9001
+
+envoy:
+  enabled: true
+  image:
+    repository: envoyproxy/envoy-alpine
+    pullPolicy: IfNotPresent
+    tag: v1.21.1
+  config: ""
+  admin:
+    port: 9004
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+health:
+  liveness:
+    enabled: true
+    port: 9000
+    interval: 3
+    initialDelay: 20
+  readiness:
+    enabled: true
+    port: 9000
+    interval: 3
+    initialDelay: 20
+
+env:
+- name: ENV_NAME
+  value: "value"
+
+database:
+  enabled: true
+  host: ""
+  port: "3306"
+  username: ""
+  password: ""
+  timezone: UTC
+  enabledTls: true
+
+awsCredentials:
+  enabled: false
+  region: ap-northeast-1
+  accesskey: ""
+  secretKey: ""
+
+cognitoCredentials:
+  enabled: false
+  userPoolId: ""
+  clientId: ""


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
今回のstg, prdでのマイクロサービス間のNW構成としては、Sidecar Proxy (Envoy) を利用した構成にしようと思ってます。
なので、まずはローカル環境で同様の構成が実現できるような設定を追加しました。
また、現状ヘルスチェックのログもアクセスログ内に含まれてログが見にくい状態になっているため、ヘルスチェックのログについては出さないような設定も追加しました。

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->
* https://tilt.dev

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
実行してみたい場合、以下のコマンドで本番同様の構成で起動することができます。

```sh
# Tiltのインストール
$ brew install tilt
# マイクロサービス毎のコンフィグを編集
# -> api/config配下の `dev.yaml.temp` をコピペして `dev.yaml` を作成して、各マイクロサービスの設定を追加する
$ vi ./api/config/[dir]/dev.yaml
# Tilt経由でK8sクラスタ上にコンテナを起動
$ tilt up
```

