### PR TITLE
feat(user/api): implement create user with oauth

### DIFF
--- a/api/mock/pkg/cognito/client.go
+++ b/api/mock/pkg/cognito/client.go
@@ -133,6 +133,21 @@ func (mr *MockClientMockRecorder) ForgotPassword(ctx, username interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForgotPassword", reflect.TypeOf((*MockClient)(nil).ForgotPassword), ctx, username)
 }
 
+// GetUser mocks base method.
+func (m *MockClient) GetUser(ctx context.Context, accessToken string) (*cognito.AuthUser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUser", ctx, accessToken)
+	ret0, _ := ret[0].(*cognito.AuthUser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUser indicates an expected call of GetUser.
+func (mr *MockClientMockRecorder) GetUser(ctx, accessToken interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), ctx, accessToken)
+}
+
 // GetUsername mocks base method.
 func (m *MockClient) GetUsername(ctx context.Context, accessToken string) (string, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/cognito/client.go
+++ b/api/pkg/cognito/client.go
@@ -17,6 +17,8 @@ type Client interface {
 	// サインアウト (アクセストークン使用)
 	SignOut(ctx context.Context, accessToken string) error
 	// ユーザー情報取得 (アクセストークン使用)
+	GetUser(ctx context.Context, accessToken string) (*AuthUser, error)
+	// ユーザーID取得 (アクセストークン使用)
 	GetUsername(ctx context.Context, accessToken string) (string, error)
 	// トークンの更新 (更新トークン使用)
 	RefreshToken(ctx context.Context, refreshToken string) (*AuthResult, error)


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
OAuth認証でのユーザー作成用のAPIを実装しました

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
