### PR TITLE
feat(api/user): implement delete user api

### DIFF
--- a/api/internal/user/api/user.go
+++ b/api/internal/user/api/user.go
@@ -137,6 +137,15 @@ func (s *userService) DeleteUser(
 	if err := req.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	// TODO: 詳細の実装
+	u, err := s.db.User.Get(ctx, req.UserId)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+	if err := s.userAuth.DeleteUser(ctx, u.CognitoID); err != nil {
+		return nil, gRPCError(err)
+	}
+	if err := s.db.User.Delete(ctx, u.ID); err != nil {
+		return nil, gRPCError(err)
+	}
 	return &user.DeleteuserResponse{}, nil
 }

--- a/api/internal/user/api/user_test.go
+++ b/api/internal/user/api/user_test.go
@@ -481,6 +481,18 @@ func TestVerifyUserPassword(t *testing.T) {
 func TestDeleteUser(t *testing.T) {
 	t.Parallel()
 
+	now := jst.Now()
+	u := &entity.User{
+		ID:           "user-id",
+		CognitoID:    "cognito-id",
+		ProviderType: entity.ProviderTypeEmail,
+		Email:        "test-user@and-period.jp",
+		PhoneNumber:  "+810000000000",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		VerifiedAt:   now,
+	}
+
 	tests := []struct {
 		name   string
 		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
@@ -488,8 +500,12 @@ func TestDeleteUser(t *testing.T) {
 		expect *testResponse
 	}{
 		{
-			name:  "success",
-			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {},
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(u, nil)
+				mocks.userAuth.EXPECT().DeleteUser(ctx, "cognito-id").Return(nil)
+				mocks.db.User.EXPECT().Delete(ctx, "user-id").Return(nil)
+			},
 			req: &user.DeleteUserRequest{
 				UserId: "user-id",
 			},
@@ -504,6 +520,45 @@ func TestDeleteUser(t *testing.T) {
 			req:   &user.DeleteUserRequest{},
 			expect: &testResponse{
 				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to delete cognito user",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(u, errmock)
+			},
+			req: &user.DeleteUserRequest{
+				UserId: "user-id",
+			},
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to delete cognito user",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(u, nil)
+				mocks.userAuth.EXPECT().DeleteUser(ctx, "cognito-id").Return(errmock)
+			},
+			req: &user.DeleteUserRequest{
+				UserId: "user-id",
+			},
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to delete user",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(u, nil)
+				mocks.userAuth.EXPECT().DeleteUser(ctx, "cognito-id").Return(nil)
+				mocks.db.User.EXPECT().Delete(ctx, "user-id").Return(errmock)
+			},
+			req: &user.DeleteUserRequest{
+				UserId: "user-id",
+			},
+			expect: &testResponse{
+				code: codes.Internal,
 			},
 		},
 	}

--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -45,6 +45,7 @@ type User interface {
 	GetByCognitoID(ctx context.Context, cognitoID string, fields ...string) (*entity.User, error)
 	Create(ctx context.Context, user *entity.User) error
 	UpdateVerified(ctx context.Context, userID string) error
+	Delete(ctx context.Context, userID string) error
 }
 
 /**

--- a/api/internal/user/database/user.go
+++ b/api/internal/user/database/user.go
@@ -97,3 +97,24 @@ func (u *user) UpdateVerified(ctx context.Context, userID string) error {
 	})
 	return dbError(err)
 }
+
+func (u *user) Delete(ctx context.Context, userID string) error {
+	_, err := u.db.Transaction(func(tx *gorm.DB) (interface{}, error) {
+		var current *entity.User
+		err := tx.Table(userTable).Select("id").
+			Where("id = ?", userID).
+			First(&current).Error
+		if err != nil || current.ID == "" {
+			return nil, err
+		}
+
+		params := map[string]interface{}{
+			"deleted_at": u.now(),
+		}
+		err = tx.Table(userTable).
+			Where("id = ?", userID).
+			Updates(params).Error
+		return nil, err
+	})
+	return dbError(err)
+}

--- a/api/internal/user/database/user_test.go
+++ b/api/internal/user/database/user_test.go
@@ -317,6 +317,72 @@ func TestUser_UpdateVerified(t *testing.T) {
 	}
 }
 
+func TestUser_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m, err := newMocks(ctrl)
+	require.NoError(t, err)
+	current := jst.Date(2022, 1, 2, 18, 30, 0, 0)
+	now := func() time.Time {
+		return current
+	}
+
+	type args struct {
+		userID string
+	}
+	type want struct {
+		hasErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				u := testUser("user-id", "test-user@and-period.jp", "+810000000000", now())
+				err = m.db.DB.Create(&u).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				userID: "user-id",
+			},
+			want: want{
+				hasErr: false,
+			},
+		},
+		{
+			name:  "failed to not found",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				userID: "user-id",
+			},
+			want: want{
+				hasErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := m.dbDelete(ctx, userTable)
+			require.NoError(t, err)
+			tt.setup(ctx, t, m)
+
+			db := &user{db: m.db, now: now}
+			err = db.Delete(ctx, tt.args.userID)
+			assert.Equal(t, tt.want.hasErr, err != nil, err)
+		})
+	}
+}
+
 func testUser(id, email, phoneNumber string, now time.Time) *entity.User {
 	return &entity.User{
 		ID:           id,

--- a/api/mock/user/database/database.go
+++ b/api/mock/user/database/database.go
@@ -49,6 +49,20 @@ func (mr *MockUserMockRecorder) Create(ctx, user interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUser)(nil).Create), ctx, user)
 }
 
+// Delete mocks base method.
+func (m *MockUser) Delete(ctx context.Context, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockUserMockRecorder) Delete(ctx, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockUser)(nil).Delete), ctx, userID)
+}
+
 // Get mocks base method.
 func (m *MockUser) Get(ctx context.Context, userID string, fields ...string) (*entity.User, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
購入者退会APIの実装をしました

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->
* https://calmato.kibe.la/notes/662

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
