### PR TITLE
feat: create auth api mock

### DIFF
--- a/api/internal/gateway/user/v1/handler/api.go
+++ b/api/internal/gateway/user/v1/handler/api.go
@@ -53,12 +53,24 @@ func NewAPIV1Handler(params *Params) APIV1Handler {
  * routes
  * ###############################################
  */
-func (h *apiV1Handler) AuthRoutes(rg *gin.RouterGroup) {}
+func (h *apiV1Handler) AuthRoutes(rg *gin.RouterGroup) {
+	rg.GET("/v1/users/me", h.GetUserMe)
+	rg.DELETE("/v1/users/me", h.DeleteUser)
+	rg.PATCH("/v1/users/me/email", h.UpdateUserEmail)
+	rg.PATCH("/v1/users/me/password", h.UpdateUserPassword)
+}
 
 func (h *apiV1Handler) NoAuthRoutes(rg *gin.RouterGroup) {
+	rg.GET("/v1/auth", h.GetAuth)
 	rg.POST("/v1/auth", h.SignIn)
 	rg.DELETE("/v1/auth", h.SignOut)
 	rg.POST("/v1/auth/refresh-token", h.RefreshAuthToken)
+	rg.POST("/v1/users", h.CreateUser)
+	rg.POST("/v1/users/oauth", h.CreateUserWithOAuth)
+	rg.POST("/v1/users/verified", h.VerifyUser)
+	rg.POST("/v1/users/me/email/verified", h.VerifyUserEmail)
+	rg.POST("/v1/users/me/forgot-password", h.ForgotUserPassword)
+	rg.POST("/v1/users/me/forgot-password/verified", h.ResetUserPassword)
 }
 
 /**

--- a/api/internal/gateway/user/v1/handler/auth.go
+++ b/api/internal/gateway/user/v1/handler/auth.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (h *apiV1Handler) GetAuth(ctx *gin.Context) {
-	// TOOD: 詳細の実装
+	// TODO: 詳細の実装
 	res := &response.AuthResponse{}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/user/v1/handler/auth.go
+++ b/api/internal/gateway/user/v1/handler/auth.go
@@ -12,6 +12,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func (h *apiV1Handler) GetAuth(ctx *gin.Context) {
+	// TOOD: 詳細の実装
+	res := &response.AuthResponse{}
+	ctx.JSON(http.StatusOK, res)
+}
+
 func (h *apiV1Handler) SignIn(ctx *gin.Context) {
 	c := util.SetMetadata(ctx)
 

--- a/api/internal/gateway/user/v1/handler/auth_test.go
+++ b/api/internal/gateway/user/v1/handler/auth_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+func TestGetAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.AuthResponse{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/auth"
+			req := newHTTPRequest(t, http.MethodGet, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
 func TestSignIn(t *testing.T) {
 	t.Parallel()
 

--- a/api/internal/gateway/user/v1/handler/user.go
+++ b/api/internal/gateway/user/v1/handler/user.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/and-period/marche/api/internal/gateway/user/v1/response"
+	"github.com/gin-gonic/gin"
+)
+
+func (h *apiV1Handler) GetUserMe(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	res := &response.UserMeResponse{}
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (h *apiV1Handler) CreateUser(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	res := &response.CreateUserResponse{}
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (h *apiV1Handler) VerifyUser(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) CreateUserWithOAuth(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	res := &response.UserMeResponse{}
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (h *apiV1Handler) UpdateUserEmail(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) VerifyUserEmail(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) UpdateUserPassword(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) ForgotUserPassword(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) ResetUserPassword(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) DeleteUser(ctx *gin.Context) {
+	// TODO: 詳細の実装
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}

--- a/api/internal/gateway/user/v1/handler/user_test.go
+++ b/api/internal/gateway/user/v1/handler/user_test.go
@@ -1,0 +1,330 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/and-period/marche/api/internal/gateway/user/v1/request"
+	"github.com/and-period/marche/api/internal/gateway/user/v1/response"
+	"github.com/golang/mock/gomock"
+)
+
+func TestGetUserMe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.UserMeResponse{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me"
+			req := newHTTPRequest(t, http.MethodGet, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.CreateUserRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.CreateUserRequest{
+				Email:                "test-user@and-period.jp",
+				PhoneNumber:          "+819012345678",
+				Password:             "!Qaz2wsx",
+				PasswordConfirmation: "!Qaz2wsx",
+			},
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.CreateUserResponse{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users"
+			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestVerifyUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.VerifyUserRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.VerifyUserRequest{
+				ID:         "user-id",
+				VerifyCode: "123456",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/verified"
+			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestCreateUserWithOAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.UserMeResponse{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/oauth"
+			req := newHTTPRequest(t, http.MethodPost, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestUpdateUserEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.UpdateUserEmailRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.UpdateUserEmailRequest{
+				Email: "test-user@and-period.jp",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me/email"
+			req := newHTTPRequest(t, http.MethodPatch, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestVerifyUserEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.VerifyUserEmailRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.VerifyUserEmailRequest{
+				VerifyCode: "123456",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me/email/verified"
+			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestUpdateUserPassword(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.UpdateUserPasswordRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.UpdateUserPasswordRequest{
+				OldPassword:          "!Qaz2wsx",
+				NewPassword:          "!Qaz3edc",
+				PasswordConfirmation: "!Qaz3edc",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me/password"
+			req := newHTTPRequest(t, http.MethodPatch, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestForgotUserPassword(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.ForgotUserPasswordRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.ForgotUserPasswordRequest{
+				Email: "test-user@and-period.jp",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me/forgot-password"
+			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestResetUserPassword(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.ResetUserPasswordRequest
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			req: &request.ResetUserPasswordRequest{
+				Email:                "test-user@and-period.jp",
+				VerifyCode:           "123456",
+				Password:             "!Qaz2wsx",
+				PasswordConfirmation: "!Qaz2wsx",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me/forgot-password/verified"
+			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		expect *testResponse
+	}{
+		{
+			name:  "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/users/me"
+			req := newHTTPRequest(t, http.MethodDelete, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}

--- a/api/internal/gateway/user/v1/request/user.go
+++ b/api/internal/gateway/user/v1/request/user.go
@@ -1,0 +1,38 @@
+package request
+
+type CreateUserRequest struct {
+	Email                string `json:"email,omitempty"`                // メールアドレス
+	PhoneNumber          string `json:"phoneNumber,omitempty"`          // 電話番号
+	Password             string `json:"password,omitempty"`             // パスワード
+	PasswordConfirmation string `json:"passwordConfirmation,omitempty"` // パスワード (確認用)
+}
+
+type VerifyUserRequest struct {
+	ID         string `json:"id,omitempty"`         // ユーザーID
+	VerifyCode string `json:"verifyCode,omitempty"` // 検証コード
+}
+
+type UpdateUserEmailRequest struct {
+	Email string `json:"email,omitempty"` // メールアドレス
+}
+
+type VerifyUserEmailRequest struct {
+	VerifyCode string `json:"verifyCode,omitempty"` // 検証コード
+}
+
+type UpdateUserPasswordRequest struct {
+	OldPassword          string `json:"oldPassword,omitempty"`          // 現在のパスワード
+	NewPassword          string `json:"newPassword,omitempty"`          // 新しいパスワード
+	PasswordConfirmation string `json:"passwordConfirmation,omitempty"` // パスワード (確認用)
+}
+
+type ForgotUserPasswordRequest struct {
+	Email string `json:"email,omitempty"` // メールアドレス
+}
+
+type ResetUserPasswordRequest struct {
+	Email                string `json:"email,omitempty"`                // メールアドレス
+	VerifyCode           string `json:"verifyCode,omitempty"`           // 検証コード
+	Password             string `json:"password,omitempty"`             // パスワード
+	PasswordConfirmation string `json:"passwordConfirmation,omitempty"` // パスワード (確認用)
+}

--- a/api/internal/gateway/user/v1/response/user.go
+++ b/api/internal/gateway/user/v1/response/user.go
@@ -1,0 +1,11 @@
+package response
+
+type CreateUserResponse struct {
+	ID string `json:"id"` // ユーザーID
+}
+
+type UserMeResponse struct {
+	ID          string `json:"id"`          // ユーザーID
+	Email       string `json:"email"`       // メールアドレス
+	PhoneNumber string `json:"phoneNumber"` // 電話番号
+}

--- a/docs/swagger/user/components/schemas/v1/users.request.yaml
+++ b/docs/swagger/user/components/schemas/v1/users.request.yaml
@@ -1,0 +1,119 @@
+createUserRequest:
+  type: object
+  properties:
+    email:
+      type: string
+      format: email
+      description: メールアドレス
+    phoneNumber:
+      type: string
+      description: 電話番号 (国際番号 + 電話番号)
+    password:
+      type: string
+      description: パスワード (8~32文字, 英小文字,数字を少なくとも1文字ずつは含む)
+    passwordConfirmation:
+      type: string
+      description: パスワード (確認用)
+  required:
+  - email
+  - phoneNumber
+  - password
+  - passwordConfirmation
+  example:
+    email: 'test-user@and-period.jp'
+    phoneNumber: '+819012345678'
+    password: '12345678'
+    passwordConfirmation: '12345678'
+verifyUserRequest:
+  type: object
+  properties:
+    id:
+      type: string
+      description: ユーザーID
+    verifyCode:
+      type: string
+      description: 認証コード
+  required:
+  - id
+  - verifyCode
+  example:
+    id: 'kSByoE6FetnPs5Byk3a9Zx'
+    verifyCode: '123456'
+updateUserEmailRequest:
+  type: object
+  properties:
+    email:
+      type: string
+      format: email
+      description: メールアドレス
+  required:
+  - email
+  example:
+    email: 'test-user@and-period.jp'
+verifyUserEmailRequest:
+  type: object
+  properties:
+    verifyCode:
+      type: string
+      description: 認証コード
+  required:
+  - verifyCode
+  example:
+    verifyCode: '123456'
+updateUserPasswordRequest:
+  type: object
+  properties:
+    oldPassword:
+      type: string
+      description: 現在のパスワード
+    newPassword:
+      type: string
+      description: 新しいパスワード (8~32文字, 英小文字,数字を少なくとも1文字ずつは含む)
+    passwordConfirmation:
+      type: string
+      description: パスワード (確認用)
+  required:
+  - oldPassword
+  - newPassword
+  - passwordConfirmation
+  example:
+    oldPassword: '12345678'
+    newPassword: '12345678'
+    passwordConfirmation: '12345678'
+forgotUserPasswordRequest:
+  type: object
+  properties:
+    email:
+      type: string
+      format: email
+      description: メールアドレス
+  required:
+  - email
+  example:
+    email: 'test-user@and-period.jp'
+resetUserPasswordRequest:
+  type: object
+  properties:
+    email:
+      type: string
+      format: email
+      description: メールアドレス
+    verifyCode:
+      type: string
+      description: 検証コード
+    password:
+      type: string
+      description: パスワード (8~32文字, 英小文字,数字を少なくとも1文字ずつは含む)
+    passwordConfirmation:
+      type: string
+      description: パスワード (確認用)
+  required:
+  - email
+  - verifyCode
+  - password
+  - passwordConfirmation
+  example:
+    email: 'test-user@and-period.jp'
+    verifyCode: '123456'
+    password: '12345678'
+    passwordConfirmation: '12345678'

--- a/docs/swagger/user/components/schemas/v1/users.response.yaml
+++ b/docs/swagger/user/components/schemas/v1/users.response.yaml
@@ -1,0 +1,30 @@
+createUserResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: ユーザーID
+  required:
+  - id
+  example:
+    id: 'kSByoE6FetnPs5Byk3a9Zx'
+userMeResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: ユーザーID
+    email:
+      type: string
+      description: メールアドレス
+    phoneNumber:
+      type: string
+      description: 電話番号
+  required:
+  - id
+  - email
+  - phoneNumber
+  example:
+    id: 'kSByoE6FetnPs5Byk3a9Zx'
+    email: 'test-user@and-period.jp'
+    phoneNumber: '+819012345678'

--- a/docs/swagger/user/openapi.yaml
+++ b/docs/swagger/user/openapi.yaml
@@ -9,12 +9,31 @@ servers:
 tags:
 - name: Auth
   description: 認証関連
+- name: User
+  description: 購入者関連
 paths:
   # Auth
   /v1/auth:
     $ref: './paths/v1/auth/index.yaml'
   /v1/auth/refresh-token:
     $ref: './paths/v1/auth/refresh-token.yaml'
+  # User
+  /v1/users:
+    $ref: './paths/v1/users/index.yaml'
+  /v1/users/me:
+    $ref: './paths/v1/users/me/index.yaml'
+  /v1/users/me/email:
+    $ref: './paths/v1/users/me/email/index.yaml'
+  /v1/users/me/email/verified:
+    $ref: './paths/v1/users/me/email/verified.yaml'
+  /v1/users/me/forgot-password:
+    $ref: './paths/v1/users/me/forgot-password/index.yaml'
+  /v1/users/me/forgot-password/me/verified:
+    $ref: './paths/v1/users/me/forgot-password/verified.yaml'
+  /v1/users/oauth:
+    $ref: './paths/v1/users/oauth.yaml'
+  /v1/users/verified:
+    $ref: './paths/v1/users/verified.yaml'
 components:
   securitySchemes:
     BearerAuth:
@@ -29,6 +48,24 @@ components:
       $ref: './components/schemas/v1/auth.request.yaml#/signInRequest'
     v1RefreshAuthTokenRequest:
       $ref: './components/schemas/v1/auth.request.yaml#/refreshAuthTokenRequest'
+    v1CreateUserRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/createUserRequest'
+    v1VerifyUserRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/verifyUserRequest'
+    v1UpdateUserEmailRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/updateUserEmailRequest'
+    v1VerifyUserEmailRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/verifyUserEmailRequest'
+    v1UpdateUserPasswordRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/updateUserPasswordRequest'
+    v1ForgotUserPasswordRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/forgotUserPasswordRequest'
+    v1ResetUserPasswordRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/resetUserPasswordRequest'
     # Response
     v1AuthResponse:
       $ref: './components/schemas/v1/auth.response.yaml#/authResponse'
+    v1CreateUserResponse:
+      $ref: './components/schemas/v1/users.response.yaml#/createUserResponse'
+    v1UserMeResponse:
+      $ref: './components/schemas/v1/users.response.yaml#/userMeResponse'

--- a/docs/swagger/user/paths/v1/auth/index.yaml
+++ b/docs/swagger/user/paths/v1/auth/index.yaml
@@ -1,5 +1,26 @@
+get:
+  summary: トークン検証
+  operationId: v1GetAuth
+  tags:
+  - Auth
+  security:
+  - BearerAuth: []
+  responses:
+    200:
+      description: A successful response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../openapi.yaml#/components/schemas/errorResponse'
 post:
   summary: サインイン
+  operationId: v1SignIn
   tags:
   - Auth
   security:
@@ -25,6 +46,7 @@ post:
             $ref: './../../../openapi.yaml#/components/schemas/errorResponse'
 delete:
   summary: サインアウト
+  operationId: v1SignOut
   tags:
   - Auth
   security:
@@ -33,7 +55,8 @@ delete:
     204:
       description: A successful response.
       content:
-        application/json: {}
+        application/json:
+          schema: {}
     default:
       description: An unexpected error response.
       content:

--- a/docs/swagger/user/paths/v1/users/index.yaml
+++ b/docs/swagger/user/paths/v1/users/index.yaml
@@ -1,23 +1,21 @@
 post:
-  summary: トークン更新
-  operationId: v1RefreshAuthToken
+  summary: 購入者登録 (メール/SMS認証)
+  operationId: v1CreateUser
   tags:
-  - Auth
-  security:
-  - BearerAuth: []
+  - User
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: './../../../openapi.yaml#/components/schemas/v1RefreshAuthTokenRequest'
+          $ref: './../../../openapi.yaml#/components/schemas/v1CreateUserRequest'
   responses:
     200:
       description: A successful response.
       content:
         application/json:
           schema:
-            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+            $ref: './../../../openapi.yaml#/components/schemas/v1UserMeResponse'
     default:
       description: An unexpected error response.
       content:

--- a/docs/swagger/user/paths/v1/users/me/email/index.yaml
+++ b/docs/swagger/user/paths/v1/users/me/email/index.yaml
@@ -1,0 +1,25 @@
+patch:
+  summary: メールアドレス更新
+  operationId: v1UpdateUserEmail
+  tags:
+  - User
+  security:
+  - BearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../../../openapi.yaml#/components/schemas/v1UpdateUserEmailRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json:
+          schema: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/user/paths/v1/users/me/email/verified.yaml
+++ b/docs/swagger/user/paths/v1/users/me/email/verified.yaml
@@ -1,8 +1,8 @@
 post:
-  summary: トークン更新
-  operationId: v1RefreshAuthToken
+  summary: メールアドレス更新 - コード検証
+  operationId: v1VerifyUserEmail
   tags:
-  - Auth
+  - User
   security:
   - BearerAuth: []
   requestBody:
@@ -10,17 +10,16 @@ post:
     content:
       application/json:
         schema:
-          $ref: './../../../openapi.yaml#/components/schemas/v1RefreshAuthTokenRequest'
+          $ref: './../../../../../openapi.yaml#/components/schemas/v1VerifyUserEmailRequest'
   responses:
-    200:
+    204:
       description: A successful response.
       content:
         application/json:
-          schema:
-            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+          schema: {}
     default:
       description: An unexpected error response.
       content:
         application/json:
           schema:
-            $ref: './../../../openapi.yaml#/components/schemas/errorResponse'
+            $ref: './../../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/user/paths/v1/users/me/forgot-password/index.yaml
+++ b/docs/swagger/user/paths/v1/users/me/forgot-password/index.yaml
@@ -1,0 +1,23 @@
+post:
+  summary: パスワードリセット
+  operationId: v1ForgotUserPassword
+  tags:
+  - User
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../../../openapi.yaml#/components/schemas/v1ForgotUserPasswordRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json:
+          schema: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/user/paths/v1/users/me/forgot-password/verified.yaml
+++ b/docs/swagger/user/paths/v1/users/me/forgot-password/verified.yaml
@@ -1,0 +1,23 @@
+post:
+  summary: パスワードリセット - コード検証
+  operationId: v1ResetUserPassword
+  tags:
+  - User
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../../../openapi.yaml#/components/schemas/v1ResetUserPasswordRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json:
+          schema: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/user/paths/v1/users/me/index.yaml
+++ b/docs/swagger/user/paths/v1/users/me/index.yaml
@@ -1,0 +1,39 @@
+get:
+  summary: 購入者情報取得
+  operationId: v1GetUserMe
+  tags:
+  - User
+  security:
+  - BearerAuth: []
+  responses:
+    200:
+      description: A successful response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/v1UserMeResponse'
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'
+delete:
+  summary: 購入者退会
+  operationId: v1DeleteUser
+  tags:
+  - User
+  security:
+  - BearerAuth: []
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json:
+          schema: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/user/paths/v1/users/me/password.yaml
+++ b/docs/swagger/user/paths/v1/users/me/password.yaml
@@ -1,8 +1,8 @@
-post:
-  summary: トークン更新
-  operationId: v1RefreshAuthToken
+patch:
+  summary: パスワード更新
+  operationId: v1UpdateUserPassword
   tags:
-  - Auth
+  - User
   security:
   - BearerAuth: []
   requestBody:
@@ -10,14 +10,13 @@ post:
     content:
       application/json:
         schema:
-          $ref: './../../../openapi.yaml#/components/schemas/v1RefreshAuthTokenRequest'
+          $ref: './../../../openapi.yaml#/components/schemas/v1UpdateUserPasswordRequest'
   responses:
-    200:
+    204:
       description: A successful response.
       content:
         application/json:
-          schema:
-            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+          schema: {}
     default:
       description: An unexpected error response.
       content:

--- a/docs/swagger/user/paths/v1/users/oauth.yaml
+++ b/docs/swagger/user/paths/v1/users/oauth.yaml
@@ -1,23 +1,22 @@
 post:
-  summary: トークン更新
-  operationId: v1RefreshAuthToken
+  summary: 購入者登録 (SNS認証)
+  operationId: v1CreateUserWithOAuth
   tags:
-  - Auth
+  - User
   security:
   - BearerAuth: []
   requestBody:
     required: true
     content:
       application/json:
-        schema:
-          $ref: './../../../openapi.yaml#/components/schemas/v1RefreshAuthTokenRequest'
+        schema: {}
   responses:
     200:
       description: A successful response.
       content:
         application/json:
           schema:
-            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+            $ref: './../../../openapi.yaml#/components/schemas/v1UserMeResponse'
     default:
       description: An unexpected error response.
       content:

--- a/docs/swagger/user/paths/v1/users/verified.yaml
+++ b/docs/swagger/user/paths/v1/users/verified.yaml
@@ -1,23 +1,20 @@
 post:
-  summary: トークン更新
-  operationId: v1RefreshAuthToken
+  summary: 購入者登録 - コード検証 (メール/SMS認証)
+  operationId: v1VerifyUser
   tags:
-  - Auth
-  security:
-  - BearerAuth: []
+  - User
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: './../../../openapi.yaml#/components/schemas/v1RefreshAuthTokenRequest'
+          $ref: './../../../openapi.yaml#/components/schemas/v1VerifyUserRequest'
   responses:
-    200:
+    204:
       description: A successful response.
       content:
         application/json:
-          schema:
-            $ref: './../../../openapi.yaml#/components/schemas/v1AuthResponse'
+          schema: {}
     default:
       description: An unexpected error response.
       content:


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
フロントエンドの実装が進められるように認証関連APIのMockを作成しておきました。
(Swagger周りの追記もしていて型定義の配布もできる状態になっているので、 #18 のマージがされ次第配布したいと思います)

レビュー観点としては、Swaggerで書いたものから生成された↓の中身を見ていただければ大丈夫です🙏

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->
[swagger.zip](https://github.com/and-period/marche/files/8240219/swagger.zip)

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
