### PR TITLE
feat(gateway): implement get auth api

### DIFF
--- a/api/internal/gateway/user/v1/handler/api_test.go
+++ b/api/internal/gateway/user/v1/handler/api_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	idmock  = "kSByoE6FetnPs5Byk3a9Zx"
-	errmock = errors.New("some error")
+	idmock    = "kSByoE6FetnPs5Byk3a9Zx"
+	tokenmock = "eyJraWQiOiJXOWxyODBzODRUVXQ3eWdyZ"
+	errmock   = errors.New("some error")
 )
 
 type mocks struct {
@@ -134,6 +135,7 @@ func newHTTPRequest(t *testing.T, method, path string, body interface{}) *http.R
 	require.NoError(t, err, err)
 
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenmock))
 	req.Header.Add("userId", idmock)
 	return req
 }
@@ -166,6 +168,7 @@ func newMultipartRequest(t *testing.T, method, path, field string) *http.Request
 	require.NoError(t, err, err)
 
 	req.Header.Add("Content-Type", writer.FormDataContentType())
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenmock))
 	req.Header.Add("userId", idmock)
 	return req
 }

--- a/api/internal/gateway/user/v1/handler/auth.go
+++ b/api/internal/gateway/user/v1/handler/auth.go
@@ -13,8 +13,27 @@ import (
 )
 
 func (h *apiV1Handler) GetAuth(ctx *gin.Context) {
-	// TODO: 詳細の実装
-	res := &response.AuthResponse{}
+	c := util.SetMetadata(ctx)
+
+	token, err := util.GetAuthToken(ctx)
+	if err != nil {
+		unauthorized(ctx, err)
+		return
+	}
+
+	in := &user.GetUserAuthRequest{
+		AccessToken: token,
+	}
+	out, err := h.user.GetUserAuth(c, in)
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
+	auth := gentity.NewUserAuth(out.Auth)
+
+	res := &response.AuthResponse{
+		Auth: entity.NewAuth(auth),
+	}
 	ctx.JSON(http.StatusOK, res)
 }
 

--- a/api/internal/gateway/user/v1/handler/auth_test.go
+++ b/api/internal/gateway/user/v1/handler/auth_test.go
@@ -14,17 +14,46 @@ import (
 func TestGetAuth(t *testing.T) {
 	t.Parallel()
 
+	auth := &user.UserAuth{
+		UserId:       "user-id",
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresIn:    3600,
+	}
+
 	tests := []struct {
 		name   string
 		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
 		expect *testResponse
 	}{
 		{
-			name:  "success",
-			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
+			name: "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.GetUserAuthRequest{AccessToken: tokenmock}
+				out := &user.GetUserAuthResponse{Auth: auth}
+				mocks.user.EXPECT().GetUserAuth(gomock.Any(), in).Return(out, nil)
+			},
 			expect: &testResponse{
 				code: http.StatusOK,
-				body: &response.AuthResponse{},
+				body: &response.AuthResponse{
+					Auth: &entity.Auth{
+						UserID:       "user-id",
+						AccessToken:  "access-token",
+						RefreshToken: "refresh-token",
+						ExpiresIn:    3600,
+						TokenType:    "Bearer",
+					},
+				},
+			},
+		},
+		{
+			name: "failed to get user auth",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.GetUserAuthRequest{AccessToken: tokenmock}
+				mocks.user.EXPECT().GetUserAuth(gomock.Any(), in).Return(nil, errmock)
+			},
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
 			},
 		},
 	}
@@ -108,6 +137,48 @@ func TestSignIn(t *testing.T) {
 			t.Parallel()
 			const path = "/v1/auth"
 			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestSignOut(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.SignOutUserRequest{AccessToken: tokenmock}
+				out := &user.SignOutUserResponse{}
+				mocks.user.EXPECT().SignOutUser(gomock.Any(), in).Return(out, nil)
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+		{
+			name: "failed to sign out user",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.SignOutUserRequest{AccessToken: tokenmock}
+				mocks.user.EXPECT().SignOutUser(gomock.Any(), in).Return(nil, errmock)
+			},
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/auth"
+			req := newHTTPRequest(t, http.MethodDelete, path, nil)
 			testHTTP(t, tt.setup, tt.expect, req)
 		})
 	}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* 認証情報取得APIの実装

## リファレンス

<!-- Issue,仕様書などの参照できるものがあれば -->
* https://calmato.kibe.la/notes/662

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
