### PR TITLE
Feat/api/create user schema

### DIFF
--- a/api/internal/gateway/user/v1/request/user.go
+++ b/api/internal/gateway/user/v1/request/user.go
@@ -1,6 +1,8 @@
 package request
 
 type CreateUserRequest struct {
+	Username             string `json:"username,omitempty"`             // ユーザー名
+	UserID               string `json:"userId,omitempty"`               // ユーザーID
 	Email                string `json:"email,omitempty"`                // メールアドレス
 	PhoneNumber          string `json:"phoneNumber,omitempty"`          // 電話番号
 	Password             string `json:"password,omitempty"`             // パスワード

--- a/api/internal/gateway/user/v1/request/user.go
+++ b/api/internal/gateway/user/v1/request/user.go
@@ -1,8 +1,6 @@
 package request
 
 type CreateUserRequest struct {
-	Username             string `json:"username,omitempty"`             // ユーザー名
-	UserID               string `json:"userId,omitempty"`               // ユーザーID
 	Email                string `json:"email,omitempty"`                // メールアドレス
 	PhoneNumber          string `json:"phoneNumber,omitempty"`          // 電話番号
 	Password             string `json:"password,omitempty"`             // パスワード
@@ -12,6 +10,11 @@ type CreateUserRequest struct {
 type VerifyUserRequest struct {
 	ID         string `json:"id,omitempty"`         // ユーザーID
 	VerifyCode string `json:"verifyCode,omitempty"` // 検証コード
+}
+
+type InitializeUserRequest struct {
+	Username string `json:"username,omitempty"` // ユーザー名
+	UserID   string `json:"userId,omitempty"`   // ユーザーID
 }
 
 type UpdateUserEmailRequest struct {

--- a/api/internal/gateway/user/v1/request/user.go
+++ b/api/internal/gateway/user/v1/request/user.go
@@ -13,8 +13,8 @@ type VerifyUserRequest struct {
 }
 
 type InitializeUserRequest struct {
-	Username string `json:"username,omitempty"` // ユーザー名
-	UserID   string `json:"userId,omitempty"`   // ユーザーID
+	Username  string `json:"username,omitempty"`  // ユーザー名
+	AccountID string `json:"accountId,omitempty"` // ユーザーID(表示名)
 }
 
 type UpdateUserEmailRequest struct {

--- a/api/proto/user/service.proto
+++ b/api/proto/user/service.proto
@@ -85,7 +85,7 @@ message VerifyUserRequest {
 message VerifyUserResponse {}
 
 message InitializeUserRequest {
-  string id       = 1 [(validate.rules).string = { min_len: 1 }];
+  string user_id       = 1 [(validate.rules).string = { min_len: 1 }];
   string username = 2 [(validate.rules).string = { min_len: 1, max_len: 32 }];
   string account_id  = 3 [(validate.rules).string = { min_len: 1, max_len: 32 }];
 }

--- a/api/proto/user/service.proto
+++ b/api/proto/user/service.proto
@@ -70,6 +70,8 @@ message CreateUserRequest {
   string phone_number          = 2 [(validate.rules).string = { min_len: 12, max_len: 18, pattern: "^\\+[0-9]{11,17}$" }];
   string password              = 3 [(validate.rules).string = { min_len: 8, max_len: 32, pattern: "^[a-zA-Z0-9_!@#$_%^&*.?()-=+]*$" }];
   string password_confirmation = 4 [(validate.rules).string = { min_len: 1 }];
+  string username              = 5 [(validate.rules).string = { min_len: 1, max_len: 32 }];
+  string user_id               = 6 [(validate.rules).string = { min_len: 1, max_len: 32 }];
 }
 
 message CreateUserResponse {

--- a/api/proto/user/service.proto
+++ b/api/proto/user/service.proto
@@ -17,6 +17,7 @@ service UserService {
   rpc GetUser(GetUserRequest) returns (GetUserResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
   rpc VerifyUser(VerifyUserRequest) returns (VerifyUserResponse);
+  rpc InitializeUser(InitializeUserRequest) returns (InitializeUserReaponse);
   rpc CreateUserWithOAuth(CreateUserWithOAuthRequest) returns (CreateUserWithOAuthResponse);
   rpc UpdateUserEmail(UpdateUserEmailRequest) returns (UpdateUserEmailResponse);
   rpc VerifyUserEmail(VerifyUserEmailRequest) returns (VerifyUserEmailResponse);
@@ -70,8 +71,6 @@ message CreateUserRequest {
   string phone_number          = 2 [(validate.rules).string = { min_len: 12, max_len: 18, pattern: "^\\+[0-9]{11,17}$" }];
   string password              = 3 [(validate.rules).string = { min_len: 8, max_len: 32, pattern: "^[a-zA-Z0-9_!@#$_%^&*.?()-=+]*$" }];
   string password_confirmation = 4 [(validate.rules).string = { min_len: 1 }];
-  string username              = 5 [(validate.rules).string = { min_len: 1, max_len: 32 }];
-  string user_id               = 6 [(validate.rules).string = { min_len: 1, max_len: 32 }];
 }
 
 message CreateUserResponse {
@@ -84,6 +83,14 @@ message VerifyUserRequest {
 }
 
 message VerifyUserResponse {}
+
+message InitializeUserRequest {
+  string id       = 1 [(validate.rules).string = { min_len: 1 }];
+  string username = 2 [(validate.rules).string = { min_len: 1, max_len: 32 }];
+  string user_id  = 3 [(validate.rules).string = { min_len: 1, max_len: 32 }];
+}
+
+message InitializeUserReaponse {}
 
 message CreateUserWithOAuthRequest {
   string access_token = 1 [(validate.rules).string = { min_len: 1 }];

--- a/api/proto/user/service.proto
+++ b/api/proto/user/service.proto
@@ -17,7 +17,7 @@ service UserService {
   rpc GetUser(GetUserRequest) returns (GetUserResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
   rpc VerifyUser(VerifyUserRequest) returns (VerifyUserResponse);
-  rpc InitializeUser(InitializeUserRequest) returns (InitializeUserReaponse);
+  rpc InitializeUser(InitializeUserRequest) returns (InitializeUserResponse);
   rpc CreateUserWithOAuth(CreateUserWithOAuthRequest) returns (CreateUserWithOAuthResponse);
   rpc UpdateUserEmail(UpdateUserEmailRequest) returns (UpdateUserEmailResponse);
   rpc VerifyUserEmail(VerifyUserEmailRequest) returns (VerifyUserEmailResponse);
@@ -87,10 +87,10 @@ message VerifyUserResponse {}
 message InitializeUserRequest {
   string id       = 1 [(validate.rules).string = { min_len: 1 }];
   string username = 2 [(validate.rules).string = { min_len: 1, max_len: 32 }];
-  string user_id  = 3 [(validate.rules).string = { min_len: 1, max_len: 32 }];
+  string account_id  = 3 [(validate.rules).string = { min_len: 1, max_len: 32 }];
 }
 
-message InitializeUserReaponse {}
+message InitializeUserResponse {}
 
 message CreateUserWithOAuthRequest {
   string access_token = 1 [(validate.rules).string = { min_len: 1 }];

--- a/docs/swagger/user/components/schemas/v1/users.request.yaml
+++ b/docs/swagger/user/components/schemas/v1/users.request.yaml
@@ -24,6 +24,21 @@ createUserRequest:
     phoneNumber: '+819012345678'
     password: '12345678'
     passwordConfirmation: '12345678'
+initializeUserRequest:
+  type: object
+  properties:
+    username:
+      type: string
+      description: ユーザー名(表示用)
+    userId:
+      type: string
+      description: ユーザーID(検索用)
+  required:
+  - username
+  - userId
+  example:
+    username: 'あんどぴりおど'
+    userId: '12345678'
 verifyUserRequest:
   type: object
   properties:

--- a/docs/swagger/user/components/schemas/v1/users.request.yaml
+++ b/docs/swagger/user/components/schemas/v1/users.request.yaml
@@ -30,15 +30,15 @@ initializeUserRequest:
     username:
       type: string
       description: ユーザー名(表示用)
-    userId:
+    accountId:
       type: string
       description: ユーザーID(検索用)
   required:
   - username
-  - userId
+  - accountId
   example:
     username: 'あんどぴりおど'
-    userId: '12345678'
+    accountId: '12345678'
 verifyUserRequest:
   type: object
   properties:

--- a/docs/swagger/user/openapi.yaml
+++ b/docs/swagger/user/openapi.yaml
@@ -22,6 +22,8 @@ paths:
     $ref: './paths/v1/users/index.yaml'
   /v1/users/me:
     $ref: './paths/v1/users/me/index.yaml'
+  /v1/users/me/initialized:
+    $ref: './paths/v1/users/me/initialized.yaml'
   /v1/users/me/email:
     $ref: './paths/v1/users/me/email/index.yaml'
   /v1/users/me/email/verified:
@@ -50,6 +52,8 @@ components:
       $ref: './components/schemas/v1/auth.request.yaml#/refreshAuthTokenRequest'
     v1CreateUserRequest:
       $ref: './components/schemas/v1/users.request.yaml#/createUserRequest'
+    v1InitializeUserRequest:
+      $ref: './components/schemas/v1/users.request.yaml#/initializeUserRequest'
     v1VerifyUserRequest:
       $ref: './components/schemas/v1/users.request.yaml#/verifyUserRequest'
     v1UpdateUserEmailRequest:

--- a/docs/swagger/user/paths/v1/users/me/initialized.yaml
+++ b/docs/swagger/user/paths/v1/users/me/initialized.yaml
@@ -1,0 +1,23 @@
+patch:
+  summary: 初回登録(表示名, 検索名)
+  operationId: v1InitializeUser
+  tags:
+  - User
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../../openapi.yaml#/components/schemas/v1InitializeUserRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json:
+          schema: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/infra/mysql/schema/2022022501-users-create-users.sql
+++ b/infra/mysql/schema/2022022501-users-create-users.sql
@@ -1,9 +1,12 @@
 CREATE SCHEMA IF NOT EXISTS `users` DEFAULT CHARACTER SET utf8mb4;
 
 CREATE TABLE `users`.`users` (
-  `id`            VARCHAR(22)  NOT NULL,          -- ユーザーID
+
+  `id`            VARCHAR(22)  NOT NULL,          -- ユーザーID (Primary Key用)
+  `user_id`       VARCHAR(32)  NOT NULL,          -- ユーザーID (表示用)
   `cognito_id`    VARCHAR(36)  NOT NULL,          -- ユーザーID (Cognito)
   `provider_type` INT          NOT NULL,          -- 認証種別
+  `username`      VARCHAR(32)  NOT NULL,          -- ユーザー名 (表示用)
   `email`         VARCHAR(256) NULL DEFAULT NULL, -- メールアドレス
   `phone_number`  VARCHAR(18)  NULL DEFAULT NULL, -- 電話番号 (国際番号(3桁)+国番号以下(15桁))
   `created_at`    DATETIME     NOT NULL,          -- 登録日時

--- a/infra/mysql/schema/2022022501-users-create-users.sql
+++ b/infra/mysql/schema/2022022501-users-create-users.sql
@@ -1,12 +1,9 @@
 CREATE SCHEMA IF NOT EXISTS `users` DEFAULT CHARACTER SET utf8mb4;
 
 CREATE TABLE `users`.`users` (
-
   `id`            VARCHAR(22)  NOT NULL,          -- ユーザーID (Primary Key用)
-  `user_id`       VARCHAR(32)  NOT NULL,          -- ユーザーID (表示用)
   `cognito_id`    VARCHAR(36)  NOT NULL,          -- ユーザーID (Cognito)
   `provider_type` INT          NOT NULL,          -- 認証種別
-  `username`      VARCHAR(32)  NOT NULL,          -- ユーザー名 (表示用)
   `email`         VARCHAR(256) NULL DEFAULT NULL, -- メールアドレス
   `phone_number`  VARCHAR(18)  NULL DEFAULT NULL, -- 電話番号 (国際番号(3桁)+国番号以下(15桁))
   `created_at`    DATETIME     NOT NULL,          -- 登録日時

--- a/infra/mysql/schema/2022041501-users-add-column.sql
+++ b/infra/mysql/schema/2022041501-users-add-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users`.`users` ADD COLUMN `account_id` VARCHAR(32) NOT NULL;
+ALTER TABLE `users`.`users` ADD COLUMN `username`   VARCHAR(32) NOT NULL;


### PR DESCRIPTION
## やったこと
・ユーザー登録(CreateUser)のリクエスト値に、Username, UserIDを追加
・user用のテーブルに、user_id, usernameのカラムを追加

## リファレンス
https://calmato.kibe.la/notes/662#%E7%99%BB%E9%8C%B2-%E3%83%A1%E3%83%BC%E3%83%ABsms%E8%AA%8D%E8%A8%BC
https://calmato.kibe.la/notes/662#%E3%82%B9%E3%82%AD%E3%83%BC%E3%83%9E%E8%A8%AD%E8%A8%88

## 残タスク

## 備考
